### PR TITLE
Расширен лист Hearthkyn Salvagers описаниями лора

### DIFF
--- a/elucidian-starstriders-cheatsheet.html
+++ b/elucidian-starstriders-cheatsheet.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Элусидианские Старстрайдеры (Elucidian Starstriders Cheat Sheet)</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page-starstriders" data-page="elucidian-starstriders">
+<header class="site-header" role="banner">
+  <div class="header-inner">
+    <a class="brand" href="necron-cheatsheet.html">Kill Team HQ</a>
+    <nav class="site-nav" aria-label="Основная навигация" data-nav></nav>
+  </div>
+</header>
+<main class="page page--sheet">
+  <header class="page-hero page-hero--split">
+    <div class="page-hero__header">
+      <p class="page-hero__eyebrow">Боевой лист Kill Team</p>
+      <h1 class="page-hero__title">Элусидианские Старстрайдеры</h1>
+      <p class="page-hero__lead">Рушьте блокаду вольного торговца, мобилизуйте ресурсы и поддерживайте наступление с орбиты. Этот лист содержит ключевые правила, плои и профили команды Элусии Вэйн.</p>
+    </div>
+    <div class="page-hero__body">
+      <p>Собранные здесь переводы согласованы с глоссарием Kill Team HQ: важные названия снабжены оригиналами в скобках. Структура страницы повторяет другие шпаргалки проекта и совместима с существующими скриптами навигации.</p>
+    </div>
+  </header>
+
+  <div class="page-layout">
+    <div class="sheet">
+      <section>
+        <h2 id="faction-rules" class="section-title">Правила фракции (Faction Rules)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="warrant-of-trade" >Письмо на торговлю (Warrant of Trade)</h3>
+            <p>Полномочия вольного торговца открывают невиданные возможности. До трёх раз за битву вы можете применить одно из правил «Письмо на торговлю (Warrant of Trade)». Нельзя использовать одно и то же правило более одного раза за битву.</p>
+            <ul>
+              <li><strong>«Вознаграждение» (Consideration):</strong> примените во время шага «Выбор оперативников» (Select Operatives) после раскрытия вариантов снаряжения. Выберите дополнительный вариант снаряжения, который не выбирали ранее.</li>
+              <li><strong>«Скоординировать» (Coordinate):</strong> примените в конце шага «Выбор оперативников» (Select Operatives). Получите 1 дополнительное очко командования (CP).</li>
+              <li><strong>«Принудить» (Coerce):</strong> примените в начале шага «Выставление оперативников» (Set Up Operatives). Выберите один из эффектов: соперник выставляет всё своё снаряжение до того, как вы выставите любое; или вы выставляете всё своё снаряжение до соперника; или соперник выставляет всех своих оперативников до того, как вы выставите любых.</li>
+              <li><strong>«Разведать» (Explore):</strong> примените во время Стратегического гамбита (Strategic Gambit) в первом игровом ходе (turning point). Выполните бесплатное действие Перестроение (Reposition) дружественным оперативником ELUCIDIAN STARSTRIDER, полностью находящимся в вашей зоне высадки (drop zone); перемещение должно закончиться в пределах 3" от вашей зоны высадки.</li>
+              <li><strong>«Подкупить» (Bribe):</strong> примените, когда наступает ваша очередь активировать оперативника. Вы можете пропустить эту активацию.</li>
+              <li><strong>«Захватить» (Seize):</strong> примените в Стратегической фазе (Strategy phase) после броска на инициативу. Перебросьте свои кубики.</li>
+              <li><strong>«Адаптируемые условия» (Adaptable Terms, только Approved Ops):</strong> примените в конце второго игрового хода. Выберите новую тактическую операцию (tac op) или новую основную операцию (primary op). Если вы выбираете новую tac op, очки победы за прежнюю обнуляются.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3 id="privateer-support-assets">Активы поддержки корсаров (Privateer Support Assets)</h3>
+            <p>Корабль «Новая Заря» обрушивает артиллерийский дождь, направляя удары по целям в зоне боевых действий (killzone). Раз за фазу Перестрелки (Firefight phase), когда дружественный оперативник ELUCIDIAN STARSTRIDER NAVIS или ELUCIDIAN STARSTRIDER ELUCIA VHANE выполняет действие Стрельба (Shoot), выберите одно оружие из списка ниже. Каждое оружие можно выбрать только один раз за битву.</p>
+            <p>Когда дружественный оперативник использует актив поддержки, укрытие определяется иначе: цель получает спасбросок от укрытия, если какая-либо часть её основания находится под местностью с преимуществом высоты (Vantage terrain). Помните, что цель всё равно должна быть допустимой — выстрел наводит оперативник в зоне боевых действий, но удар приходит сверху.</p>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Архитекный луч (Archeotech beam)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 6/7</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Пробитие 2 (Piercing 2), Бесшумный (Silent)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменная батарея (Plasma battery)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Смертельный 5+ (Lethal 5+), Пробитие 1 (Piercing 1), Бесшумный (Silent)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Макроканон (Macrocannon)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Пробитие крита 1 (Piercing Crits 1), Насыщение (Saturate), Бесшумный (Silent), Струя 2" (Torrent 2")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Управляемый снаряд (Guided shell)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 2" (Blast 2"), Тяжёлый (Heavy, только Reposition), Бесшумный (Silent)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кассетная бомба (Cluster bomb)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 3" (Blast 3"), Тяжёлый (Heavy, только Reposition), Бесшумный (Silent)</div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="strategic-ploys" class="section-title">Стратегические плои (Strategy Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="lethal-proximity">Смертельная близость (Lethal Proximity)</h3>
+            <p>Когда дружественный оперативник ELUCIDIAN STARSTRIDER стреляет по цели в пределах 6", его дальнобойное оружие (кроме активов поддержки) получает правило Сбалансированный (Balanced).</p>
+          </article>
+          <article class="card">
+            <h3 id="stake-claim">Заявить права (Stake Claim)</h3>
+            <p>Разместите свой маркер «Претензия» (Claim marker) в зоне боевых действий. Пока дружественный оперативник ELUCIDIAN STARSTRIDER стреляет, сражается или контратакует (Retaliate) против врага в пределах 3" от маркера, его оружие получает правило Точный 1 (Accurate 1). В шаге Подготовки (Ready step) следующей Стратегической фазы удалите маркер.</p>
+          </article>
+          <article class="card">
+            <h3 id="undaunted-explorers">Бесстрашные исследователи (Undaunted Explorers)</h3>
+            <p>Впервые за ход, когда каждый дружественный оперативник ELUCIDIAN STARSTRIDER получает урон в шаге «Разрешение кубов атаки» (Resolve Attack Dice), вы можете уменьшить нанесённый урон вдвое (округляя в большую сторону, минимум 2).</p>
+          </article>
+          <article class="card">
+            <h3 id="quick-march">Стремительный марш (Quick March)</h3>
+            <p>Когда дружественный оперативник ELUCIDIAN STARSTRIDER выполняет действие Перестроение (Reposition), вы можете применить этот плой. Добавьте 1" к его характеристике Движение (Move) до конца активации, но он должен завершить перемещение ближе к зоне высадки соперника (drop zone) и не может использовать активы поддержки в эту активацию.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="firefight-ploys" class="section-title">Плои перестрелки (Firefight Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="combined-arms">Сочетание огня (Combined Arms)</h3>
+            <p>Используйте плой после броска атак у дружественного оперативника ELUCIDIAN STARSTRIDER, если цель уже подвергалась стрельбе другого дружественного оперативника ELUCIDIAN STARSTRIDER в этом игровом ходе (turning point). Перебросьте любое количество кубов атаки. Нельзя применять при использовании активов поддержки.</p>
+          </article>
+          <article class="card">
+            <h3 id="survivalist">Выживальщик (Survivalist)</h3>
+            <p>Используйте плой, когда дружественный оперативник ELUCIDIAN STARSTRIDER активируется и не находится в зоне контроля врагов. Он восстанавливает до D3+2 потерянных ран. Каждого оперативника можно лечить так не более одного раза за битву.</p>
+          </article>
+          <article class="card">
+            <h3 id="great-endurance">Великая стойкость (Great Endurance)</h3>
+            <p>Используйте плой во время активации дружественного оперативника ELUCIDIAN STARSTRIDER NAVIS. До конца активации увеличьте его характеристику действий (APL) на 1.</p>
+          </article>
+          <article class="card">
+            <h3 id="well-drilled">Отточенное взаимодействие (Well-Drilled)</h3>
+            <p>Используйте плой, когда активируется дружественный оперативник ELUCIDIAN STARSTRIDER NAVIS. Выберите другого готового дружественного оперативника NAVIS в пределах 3" и в линии видимости. Когда первый будет израсходован, вы можете немедленно активировать второго до того, как активируется соперник. После расходования второго ход переходит противнику.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-equipment" class="section-title">Снаряжение фракции (Faction Equipment)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="armoured-undersuit">Бронированный поддоспешник (Armoured Undersuit)</h3>
+            <p>Когда противник стреляет по дружественному оперативнику ELUCIDIAN STARSTRIDER (кроме CANID) со спасброском 5+, вы можете сохранить результат защиты 4 как обычный успех.</p>
+          </article>
+          <article class="card">
+            <h3 id="hot-shot-capacitor-packs">Усилители горячего выстрела (Hot Shot Capacitor Packs)</h3>
+            <p>До двух раз за ход, когда дружественный оперативник ELUCIDIAN STARSTRIDER совершает действие Стрельба (Shoot) и выбирает лазпистолет или лазган, примените правило: до конца хода добавьте 1 к базовому и критическому урону оружия и дайте ему правила Перегрев (Hot) и Пробитие крита 1 (Piercing Crits 1). Реликтовые лазпистолеты исключены.</p>
+          </article>
+          <article class="card">
+            <h3 id="improved-coordinates-uplink">Улучшенный координатный аплинк (Improved Coordinates Uplink)</h3>
+            <p>Когда дружественный оперативник ELUCIDIAN STARSTRIDER использует актив поддержки, а цель в пределах 6" от дружественного оперативника NAVIS, цель не может быть скрыта (Obscured), а оружие получает правило Насыщение (Saturate).</p>
+          </article>
+          <article class="card">
+            <h3 id="rapid-gunnery">Скоростная наводка (Rapid Gunnery)</h3>
+            <p>Раз за битву при выборе актива поддержки можно выбрать уже использованный вариант. Это отменяет ограничение «не более одного раза».</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="datacards" class="section-title">Датакарты (Datacards)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="elucia-vhane">Элуция Вэйн (Elucia Vhane)</h3>
+            <p>Мастер корабля «Новая Заря», вольная торговка Элуция Вэйн происходит из древней династии. Она владеет рапирой «Размывание» (Blur) и контролирует поле боя при помощи многочастотного ауспикатора.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Реликтовый пистолет (Heirloom relic pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие крита 1 (Piercing Crits 1), «Искать свет» (Seek Light)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Мономолекулярная трость-рапира (Monomolecular cane-rapier)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>Цифровые лазеры (Digital Lasers):</strong> в начале шага броска кубов атаки действия Сражение (Fight) нанесите 1 урон вражескому оперативнику в последовательности.</p>
+            <p><strong>Безжалостная (Merciless):</strong> когда Элуция стреляет, сражается или возмещает против уже раненной цели, её оружие получает правило Сбалансированный (Balanced); если оно уже есть, замените его на Неумолимый (Ceaseless).</p>
+            <p><strong>Поле разрушения (Disruption Field):</strong> при стрельбе по Элуции игнорируйте правило Пробитие (Piercing).</p>
+            <p><strong>Репутация превыше всего (Reputation to Maintain):</strong> впервые за битву, когда Элуция выводит врага из строя, получите 1 дополнительное CP или один дополнительный раз используйте правило «Письмо на торговлю (Warrant of Trade)» (всего до четырёх применений за битву, но без повторов).</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, LEADER, ELUCIA VHANE. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="canid">Канид (Canid)</h3>
+            <p>Бесчисленные породы канидов служат сторожами и охотниками. Любимец Вэйн по кличке Аксимион проявляет фанатичную преданность и ярость.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">8"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">7</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Яростный укус (Vicious bite)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Рвущий (Rending)</div>
+              </div>
+            </div>
+            <p><strong>Зверь (Beast):</strong> оперативник может выполнять только действия Рывок (Charge), Бросок (Dash), Отход (Fall Back), Сражение (Fight), Сбор (Gather), Караул (Guard), Перестроение (Reposition), Поднять маркер (Pick Up Marker) и Установить маркер (Place Marker). Он не может использовать оружие, отсутствующее на его дата-карте.</p>
+            <p><strong>Верный спутник (Loyal Companion):</strong> когда враг выполняет действие Сражение (Fight) и этот оперативник является допустимой целью, заставьте его выбрать канида. Если враг заканчивает действие Рывок в зоне контроля дружественного оперативника ELUCIDIAN STARSTRIDER в пределах 3", а канид свободен от контроля врагов, он может немедленно выполнить бесплатный Рывок к этому врагу.</p>
+            <p><strong>Сбор (Gather, 1AP):</strong> выполните бесплатное действие Бросок (Dash) или Перестроение (Reposition); во время перемещения можете бесплатно Поднять или Установить маркер, определив контроль. Оставшееся перемещение завершите после этого.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, CANID. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="death-cult-executioner">Палач Культа Смерти (Death Cult Executioner)</h3>
+            <p>Фанатики Культа Смерти искупают существование жертвами врагов. Кноссо Пронд поклялась уничтожить тысячу ксеносов.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Дротиковая маска (Dartmask)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 1/1</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Смертельный 5+ (Lethal 5+), Бесшумный (Silent), Оглушающий (Stun)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Энергетическое оружие (Power weapon)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>Молниеносные рефлексы (Rapid Reflexes):</strong> игнорируйте правило Пробитие (Piercing), когда враг стреляет по оперативнику.</p>
+            <p><strong>Клинковая стойка (Bladed Stance):</strong> во время Сражения (Fight) или возмездия (Retaliate) можно разрешить один успех до обычного порядка, но он должен блокировать.</p>
+            <p><strong>Ревнитель (Zealot):</strong> если оперативник выведен из строя в Сражении, нанесите противнику урон одним неиспользованным успехом перед удалением.</p>
+            <p><strong>Подготовленный убийца (Trained Assassin, 1AP):</strong> измените приказ оперативника. Нельзя выполнять, находясь под контролем врага.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, DEATH CULT EXECUTIONER. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="lectro-maester">Лектро-маэстер (Lectro-Maester)</h3>
+            <p>Техножрецы Культа Механика несут искры Движущей силы и управляют волтагаистовым полем. Ларсен ван дер Граус примкнул к экспедиции ради редких находок.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Вольтовый пистолет (Voltaic pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", 1" Опустошающий 1 (Devastating 1), Рвущий (Rending)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Удар рукояткой (Gun butt)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Миссионер марсианского культа (Missionary of the Martian Creed):</strong> раз за активацию выполняйте действия Поднять маркер (Pick Up Marker), Установить маркер (Place Marker) или миссионное действие на 1 AP дешевле.</p>
+            <p><strong>Волтагаистовая матрица (Voltaghiest Array):</strong> когда враг стреляет по дружественному оперативнику ELUCIDIAN STARSTRIDER в пределах 4", перебросьте один куб защиты.</p>
+            <p><strong>Калибровка поля (Calibrate Voltagheist, 0AP):</strong> выберите эффект до следующей активации: «Заряд» (Charge) — пистолет получает Смертельный 4+ (Lethal 4+); «Поле» (Field) — когда враг завершает действия Рывок, Бросок, Отход или Перестроение, находясь в пределах 4" и видимости, нанесите ему D6 урона. Нельзя выполнять под контролем врага.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, LECTRO-MAESTER. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="rejuvenat-adept">Реджувенат-адепт (Rejuvenat Adept)</h3>
+            <p>Мастера сохранения жизни вводят обезболивающие и проводят операции прямо на поле боя. Санистазия Минст ищет универсальное исцеление.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Лазпистолет (Laspistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Скальпель-коготь (Scalpel claw)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Рвущий (Rending)</div>
+              </div>
+            </div>
+            <p><strong>Медик! (Medic!):</strong> впервые за ход, когда дружественный оперативник ELUCIDIAN STARSTRIDER в пределах 3" и видимости должен быть выведен из строя, если никто не находится под контролем врага, вы можете оставить союзника с 3 ранами, запретив его выбивание до конца действия. После этого он выполняет бесплатный Бросок (Dash), завершаясь в зоне контроля адепта. Если правило использовано во время его активации, она заканчивается. Нельзя применять, если адепт выведен из строя или цель действия — Стрельба, где адепт был бы первичной или вторичной целью.</p>
+            <p><strong>Нормализующий шлем (Normaliser Helm):</strong> игнорируйте изменения характеристик от состояния ранения у дружественных оперативников в пределах 6".</p>
+            <p><strong>Исцеляющая сыворотка (Healing Serum, 1AP):</strong> выберите дружественного оперативника в зоне контроля и восстановите D3+3 ран. Нельзя применять к тем, кого спасали правилом «Медик!» в этот ход. Запрещено под контролем врага.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, MEDIC, REJUVENAT ADEPT. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="voidmaster">Войдмастер (Voidmaster)</h3>
+            <p>Войдмастера ведут отряды флотской пехоты. Нитш и его бойцы славятся дисциплиной и стойкостью.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Артисанское ружьё (Artificer shotgun, ближний режим)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Артисанское ружьё (Artificer shotgun, дальний режим)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 5+ • УРОН 2/2</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Реликтовый лазпистолет (Relic laspistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 2/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Смертельный 5+ (Lethal 5+)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Удар рукояткой (Gun butt)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Дисциплинатор (Disciplinarian, Support):</strong> когда дружественный оперативник NAVIS в пределах 3" стреляет, его оружие (кроме активов поддержки) получает правило Сбалансированный (Balanced); если оно уже есть, замените его на Неумолимый (Ceaseless).</p>
+            <p><strong>Крепкий характер (Hardy):</strong> раз за битву игнорируйте обычный урон от одной атаки.</p>
+            <p><strong>Непреклонный огонь (Uncompromising Fire, 1AP):</strong> выполните две бесплатные Стрельбы — одну реликтовым лазпистолетом, другую ближним режимом ружья (в любом порядке). Нельзя выполнять с приказом Скрытность (Conceal order) или в ту же активацию, что обычная Стрельба.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, NAVIS, VOIDMASTER. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="voidsman">Войдсмен (Voidsman)</h3>
+            <p>Флотские солдаты охраняют судно и экипаж, облачённые в барочную броню. Ветеран Стромиан Грелл заслужил право носить ротоканон.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">7</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Лазган (Lasgun)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ротоканон, сосредоточенный (Rotor cannon, focused)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Dash), Рвущий (Rending)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ротоканон, размахивающий (Rotor cannon, sweeping)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Dash), Рвущий (Rending), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Удар рукояткой (Gun butt)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Члены экипажа (Crewmen):</strong> раз за ход, если в этот ход вы ещё не использовали актив поддержки, можете контрдействовать (Counteract) дружественным VOIDSMAN с приказом Скрытность, но он может выполнять только действие Стрельба (Shoot) и обязан использовать актив поддержки.</p>
+            <p><strong>Ключевые слова:</strong> ELUCIDIAN STARSTRIDER, IMPERIUM, NAVIS, VOIDSMAN. Основание ⌀25 мм.</p>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <nav class="page-nav" aria-label="Навигация по листу" data-page-toc data-toc-scope=".sheet" data-toc-target=".section-title, .cards .card h3" data-toc-prefix="elucidian-starstriders" data-toc-levels=".section-title:2; .cards .card h3:3">
+      <h2>Разделы</h2>
+      <ul class="page-nav-list" data-page-toc-list></ul>
+    </nav>
+  </div>
+</main>
+<script src="scripts.js" defer></script>
+</body>
+</html>

--- a/hearthkyn-salvagers-cheatsheet.html
+++ b/hearthkyn-salvagers-cheatsheet.html
@@ -1,0 +1,611 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Хэрткин-спасатели (Hearthkyn Salvagers Cheat Sheet)</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page-hearthkyn-salvagers" data-page="hearthkyn-salvagers">
+<header class="site-header" role="banner">
+  <div class="header-inner">
+    <a class="brand" href="necron-cheatsheet.html">Kill Team HQ</a>
+    <nav class="site-nav" aria-label="Основная навигация" data-nav></nav>
+  </div>
+</header>
+<main class="page page--sheet">
+  <header class="page-hero page-hero--split">
+    <div class="page-hero__header">
+      <p class="page-hero__eyebrow">Боевой лист Kill Team</p>
+      <h1 class="page-hero__title">Хэрткин-спасатели</h1>
+      <p class="page-hero__lead">Команда Лиг Вотан, специализирующаяся на зачистке дереликтов и защите трофеев. Лист оформлен в общем стиле Kill Team HQ и содержит переводы ключевых правил и профилей.</p>
+    </div>
+    <div class="page-hero__body">
+      <p>Все термины переведены по глоссарию проекта; оригинальные названия указаны в скобках, чтобы упростить сверку с англоязычными материалами.</p>
+    </div>
+  </header>
+
+  <div class="page-layout">
+    <div class="sheet">
+      <section>
+        <h2 id="faction-rules" class="section-title">Правила фракции (Faction Rules)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="grudge" class="section-subtitle">«Затаённая обида» (Grudge)</h3>
+            <p>Если враг публично позорит или оскорбляет Кин, его имя попадает в список «затаённой обиды» (Grudge). Ради уничтожения такого противника спасатели готовы рисковать даже собственной безопасностью.</p>
+            <p>Когда вражеский оперативник выводит из строя дружеского оперативника HEARTHKYN SALVAGER, он получает один из ваших жетонов обиды (Grudge token) на весь бой.</p>
+            <p>Если дружеский HEARTHKYN SALVAGER стреляет, сражается или контратакует против врага с жетонами обиды, за каждый жетон можно удержать один обычный успех как критический. Жетоны при этом не сбрасываются.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tanked-up" class="section-subtitle">«Запас прочности» (Tanked Up)</h3>
+            <p>Грохот взрывов, запах гари и боевые крики лишь подстёгивают азарт спасателей. Чем гуще хаос битвы, тем больше сил они находят в себе.</p>
+            <p>Когда дружеский оперативник HEARTHKYN SALVAGER (кроме BOMB SQUIG) с приказом Атака (Engage order) выполняет действие Стрельба (Shoot) или Сражение (Fight), до начала его следующей активации увеличьте характеристику действий (APL) на 1.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="strategy-ploys" class="section-title">Стратегические плои (Strategy Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="need-keeps">«Нужда укрепляет» (Need Keeps)</h3>
+            <p>Те, кто сильнее всего жаждет трофея, сражаются за него яростнее остальных.</p>
+            <p>Выберите маркер цели или один из ваших миссионных маркеров.</p>
+            <ul>
+              <li>При определении контроля выбранного маркера суммарная характеристика действий дружеских HEARTHKYN SALVAGER, оспаривающих его (contest), считается на 1 выше.</li>
+              <li>Каждый дружеский HEARTHKYN SALVAGER в пределах 3" от маркера получает +1 к числу атак (Atk) своих рукопашных оружий (но не более 4).</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3 id="wrought-defence">«Кованая защита» (Wrought Defence)</h3>
+            <p>Искусные мастера Кин куют доспехи, способные выдержать смертельные залпы.</p>
+            <p>Когда по дружескому HEARTHKYN SALVAGER стреляют, и в шаге броска спасбросков (Roll Defence Dice) выпало два и более промаха, можно перебросить один из них.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="toil-earns">«Труд вознаграждается» (Toil Earns)</h3>
+            <p>Чем тяжелее достаётся добыча, тем ценнее она для клана.</p>
+            <p>Выберите маркер цели или ваш миссионный маркер. Каждый вражеский оперативник в пределах 3" от него считается имеющим дополнительный жетон обиды.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="proximate-firepower">«Ближний огонь» (Proximate Firepower)</h3>
+            <p>Хэрткин-спасатели отлично чувствуют себя в тесных коридорах, ведя огонь с минимальной дистанции.</p>
+            <p>Когда дружеский HEARTHKYN SALVAGER стреляет по врагу в пределах 6", улучшите характеристику попадания (Hit) его дальнобойных оружий на 1 (до максимума 3+). Эффект можно применять или снимать в ходе действия, приоритет над базовыми правилами.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="firefight-ploys" class="section-title">Плои перестрелки (Firefight Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="ancestors-are-watching">«Предки наблюдают» (The Ancestors Are Watching)</h3>
+            <p>Кин постоянно помнят о своих предках и вдохновляются их уроками.</p>
+            <p>Во время активации дружеского HEARTHKYN SALVAGER до конца активации он может выполнить либо бесплатную Стрельбу, либо бесплатное Сражение.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="sturdy">«Крепкий характер» (Sturdy)</h3>
+            <p>Хэрткины коренасты и упрямы: они выдерживают удары, которые свалили бы человека.</p>
+            <p>Используйте плой, когда враг стреляет по дружескому HEARTHKYN SALVAGER и вы собираете спасброски. Все критические успехи атакующего становятся обычными (уже сработавшие правила оружия, например Пробитие, сохраняются).</p>
+          </article>
+
+          <article class="card">
+            <h3 id="worth-it">«Оно того стоит» (Worth It)</h3>
+            <p>Кин готовы погибнуть, если их жертва поможет родне.</p>
+            <p>Когда дружеский HEARTHKYN SALVAGER выводится из строя, он может выполнить одно бесплатное миссионное действие перед удалением с поля.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="engage-to-acquire">«Завоевать добычу» (Engage to Acquire)</h3>
+            <p>Чтобы вернуть трофей, иногда приходится брать его штурмом.</p>
+            <p>После броска атакующих кубов дружеским HEARTHKYN SALVAGER, если цель контролирует маркер цели или ваш миссионный маркер, можно перебросить любое количество кубов атаки.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-equipment" class="section-title">Снаряжение фракции (Faction Equipment)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="plasma-knives">Плазменные ножи (Plasma Knives)</h3>
+            <p>Раскалённые клинки легко прорезают металл и кости — даже броня не спасёт от плазменного лезвия.</p>
+            <p>Все дружеские HEARTHKYN SALVAGER получают рукопашное оружие «Плазменные ножи»: 3 атаки, попадание 4+, урон 3/5, правило Смертельный 5+ (Lethal 5+). Если профиль на датакарте лучше, используйте его.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="excavation-tools">Инструменты раскопок (Excavation Tools)</h3>
+            <p>Плазморезы, гидромолоты и вибропики помогают извлекать ценные находки из обломков.</p>
+            <p>Дружеские HEARTHKYN SALVAGER выполняют действие Поднять маркер (Pick Up Marker) на 1 AP дешевле и могут делать это без контроля маркера — достаточно его оспаривать (contest).</p>
+          </article>
+
+          <article class="card">
+            <h3 id="climbing-rigs">Альпинистские системы (Climbing Rigs)</h3>
+            <p>Специальные тросы и захваты позволяют спасателям преодолевать практически любые препятствия.</p>
+            <p>При подъёме дружеского HEARTHKYN SALVAGER вертикальная дистанция считается на 1" меньше (но минимум 2"). На лестницы оборудования это не влияет.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="writ-of-claim">«Грамота притязания» (Writ of Claim)</h3>
+            <p>Обретя официальное право на трофей, кланы Вотан готовы защищать его любой ценой.</p>
+            <p>Раз за бой, если ваши HEARTHKYN SALVAGER оспаривают (contest) два и более маркера цели, после броска инициативы можно перебросить свой куб.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="datacards" class="section-title">Датакарты (Datacards)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="hearthkyn-theyn">Хэрткин-теин (Hearthkyn Theyn)</h3>
+            <p>Опытный лидер отделения с бесчисленными абордажами за плечами, возглавляющий спасательную группу.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">9</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет системы «Авток» (Autoch-pattern bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтовый револьвер (Bolt revolver)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменный пистолет «ЭтаКарн» (EtaCarn plasma pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный пистолет (Ion pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ударный рукав (Concussion gauntlet)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 5/7</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal), Шок (Shock)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменное оружие (Plasma weapon)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>«Взор Предков» (Eye of the Ancestors, STRATEGIC GAMBIT):</strong> если оперативник в зоне боя, выберите одного врага (или до двух, если выведено из строя три и более ваших HEARTHKYN SALVAGER). Каждый получает жетон обиды.</p>
+            <p><strong>«Вейвфилд-гребень» (Weavefield Crest):</strong> первый раз за бой, когда по оперативнику проходит урон 4+ за успех, игнорируйте этот урон.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, LEADER, THEYN. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-dozr">Хэрткин-дозер (Hearthkyn Dôzr)</h3>
+            <p>Массивный бурильщик, ломающий стены и врагов тяжёлыми ударными рукавами.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет системы «Авток» (Autoch-pattern bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ударные кастеты (Concussion knux)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Неумолимый (Ceaseless), Смертельный 5+ (Lethal 5+), Шок (Shock)</div>
+              </div>
+            </div>
+            <p><strong>«Драчун» (Brawler):</strong> во время Сражения или контратаки враги не могут помогать; если оперативник выведен из строя, можно ударить врага одним неиспользованным успехом до удаления.</p>
+            <p><strong>«Кастеты в дело» (Knux Smash, 1AP):</strong> выберите врага в зоне контроля, переместите до 3" (по желанию), затем нанесите D3+1 урона (если выпало 3, дополнительно -1 к APL цели до конца её следующей активации). После этого выполните бесплатный Рывок до 3".</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, DÔZR. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-field-medic">Хэрткин-полевой медик (Hearthkyn Field Medic)</h3>
+            <p>Боец, умеющий спасать товарищей под огнём и восстанавливать даже железных братьев.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтовый револьвер (Bolt revolver)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменный нож (Plasma Knife)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>«Медик!» (Medic!):</strong> первый раз за ход, когда другой дружеский HEARTHKYN SALVAGER в пределах 3" будет выведен из строя и ни один не под контролем врага, вместо этого он остаётся с 1 раной, не может быть выведен до конца действия, затем выполняет бесплатный Бросок (Dash) в зону контроля медика. Оба получают -1 к APL до конца своих следующих активаций. Если способность сработала в активации цели, она немедленно завершается.</p>
+            <p><strong>«Медкомплект» (Medikit, 1AP):</strong> восстановите дружескому HEARTHKYN SALVAGER в зоне контроля до 2D3 потерянных ран (если способность «Медик!» уже применялась к нему в этом ходу, нельзя). Нельзя выполнять в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, MEDIC, FIELD MEDIC. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-grenadier">Хэрткин-гренадёр (Hearthkyn Grenadier)</h3>
+            <p>Специалист по взрывчатке, расчищающий коридоры и блокирующий ключевые участки.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет системы «Авток» (Autoch-pattern bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Заряд C8 HX (C8 HX charge)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 4", Взрыв 1" (Blast 1"), Тяжёлое (Heavy, только Reposition), Ограниченный 1 (Limited 1), Пробитие 1 (Piercing 1), Насыщение (Saturate)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Гренадёр» (Grenadier):</strong> оперативник может использовать осколочные, бронебойные, дымовые и шоковые гранаты не ограничиваясь запасом экипировки. При использовании осколочной или бронебойной гранаты улучшите характеристику попадания на 1.</p>
+            <p><strong>«Утилитарная граната VÂYR-3» (VÂYR-3 Utility Grenade, 1AP):</strong> разместите маркер утилитарной гранаты в пределах 6", видимый или на видимом уступе с преимуществом высоты. Оперативники в 3" платят +1 AP за действия Поднять маркер и миссионные. В шаге Подготовки следующей Стратегической фазы бросьте D3 и уберите маркер после соответствующего числа завершённых активаций или в конце хода.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, GRENADIER. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-gunner">Хэрткин-пулемётчик (Hearthkyn Gunner)</h3>
+            <p>Тяжёлый стрелок, подбирающий оружие под задачу и прикрывающий продвижение отряда.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменный лучемёт «ЭтаКарн» (EtaCarn plasma beamer)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1), Луч (Beam)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Автовинтовка HYLas (HYLas auto rifle)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Неумолимый (Ceaseless), Рвущий (Rending)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ротари-пушка HYLas (фокус) (HYLas rotary cannon, focused)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Неумолимый (Ceaseless), Тяжёлое (Heavy, только Reposition), Насыщение (Saturate)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ротари-пушка HYLas (залп) (HYLas rotary cannon, sweeping)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Неумолимый (Ceaseless), Тяжёлое (Heavy, только Reposition), Насыщение (Saturate), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетная установка L7 (взрыв) (L7 missile launcher, blast)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 2" (Blast 2")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетная установка L7 (фокус) (L7 missile launcher, focused)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Рельсовая винтовка магна (Magna rail rifle)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/2</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Разрушительный 3 (Devastating 3), Тяжёлое (Heavy, только Dash), Пробитие 2 (Piercing 2)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>Правило «Луч» (Beam):</strong> каждая удержанная критическая атака немедленно наносит D3 урона каждому оперативнику вдоль выбранной лучевой линии (см. правила), кроме основной цели.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, GUNNER. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-jump-pack-warrior">Хэрткин-десантник (Hearthkyn Jump Pack Warrior)</h3>
+            <p>Оперативник с ранцевым приводом, обходящий преграды и наносящий силовые удары сверху.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">7"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет системы «Авток» (Autoch-pattern bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменное оружие (Plasma weapon)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Силовой удар (Force Impact)</div>
+              </div>
+            </div>
+            <p><strong>«Ранец-прыжок» (Jump Pack):</strong> при перемещениях можно выбрать Полёт (FLY): убрать модель, затем выставить полностью в пределах своей характеристики передвижения (или 3" для Броска) по горизонтали. В закрытых зонах нельзя пересекать стены; нельзя ставить в зоне контроля врага, кроме как после Рывка.</p>
+            <p><strong>«Силовой удар» (Force Impact):</strong> если оружие использовано в Сражении после Рывка, оно получает правило Жестокий (Brutal).</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, JUMP PACK WARRIOR. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-kinlynk">Хэрткин-кинлинк (Hearthkyn Kinlynk)</h3>
+            <p>Коммуникатор, поддерживающий связь в металлокоридорах и нарушающий передачи противника.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Сигнал» (Signal, 1AP, SUPPORT):</strong> выберите дружеского HEARTHKYN SALVAGER в 6" и в прямой видимости. До конца его следующей активации увеличьте APL на 1. Нельзя использовать в зоне контроля врага.</p>
+            <p><strong>«Глушение системы» (System Jam, 1AP):</strong> выберите видимую цель без жетона глушения. Она получает ваш жетон; пока он есть, этот оперативник активируется только после всех врагов без жетона. После активации жетон снимается. Нельзя применять в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, KINLYNK. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-kognitaar">Хэрткин-когнитар (Hearthkyn Kognitâar)</h3>
+            <p>Иронкин-аналитик, мгновенно перерабатывающий данные и направляющий огонь товарищей.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Тактик» (Tactician, STRATEGIC GAMBIT):</strong> если оперативник в зоне боя, разместите маркер Атаки или Защиты. Дружеские HEARTHKYN SALVAGER в 3" от маркера Атаки могут перебросить один куб атаки; друзья в 3" от маркера Защиты могут перебросить один спасбросок, если по ним стреляют. В шаге Подготовки следующей Стратегической фазы маркер удаляется.</p>
+            <p><strong>«Ускоренная оценка» (Accelerated Appraisal, 1AP):</strong> удалите текущий маркер (если есть) и разместите маркер Атаки или Защиты. Нельзя использовать в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, KOGNITÂAR. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-lokatr">Хэрткин-локатр (Hearthkyn Lokâtr)</h3>
+            <p>Сканировщик, отслеживающий угрозы спектральными сенсорами и подсвечивающий цели.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Отметить цель» (Spot, 1AP, SUPPORT):</strong> выберите видимого врага. До конца хода дружеские HEARTHKYN SALVAGER в 3" могут, стреляя по нему, дать оружию правило Искать свет (Seek Light) и сделать цель не скрытой. Нельзя применять в зоне контроля врага.</p>
+            <p><strong>«Панспектральное сканирование» (Pan Spectral Scan, 1AP):</strong> разместите свой маркер сканирования. Дружеские HEARTHKYN SALVAGER, стреляющие по врагам в 3" от маркера, получают Точный 1 (Accurate 1) и Насыщение (Saturate). Маркер снимается при следующей активации оперативника, его гибели или повторном использовании способности.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, LOKÂTR. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-lugger">Хэрткин-носильщик (Hearthkyn Lugger)</h3>
+            <p>Несёт боезапас и оборудование по коридорам, обеспечивая отряд ресурсами.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Хорошо снабжены» (Well Supplied):</strong> вы можете выбрать одну дополнительную опцию снаряжения для отряда.</p>
+            <p><strong>«Я донесу» (I’ve Got It):</strong> раз за активацию может выполнить миссионное действие на 1 AP дешевле.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, LUGGER. Основание ⌀28 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="hearthkyn-warrior">Хэрткин-воин (Hearthkyn Warrior)</h3>
+            <p>Стойкий пехотинец, прикрывающий специалистов и удерживающий ключевые зоны.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">8</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтер системы «Авток» (Autoch-pattern bolter)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Точный 1 (Accurate 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ионный бластер (Ion blaster)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие крит. 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+              </div>
+            </div>
+            <p><strong>«Безопасная добыча» (Secure Salvage):</strong> когда враг стреляет, сражается или контратакует против этого оперативника, и он оспаривает (contest) маркер цели или миссионный маркер, в шаге разрешения можно уменьшить урон от одного успеха на 1.</p>
+            <p><strong>Ключевые слова:</strong> HEARTHKYN SALVAGER, LEAGUES OF VOTANN, WARRIOR. Основание ⌀28 мм.</p>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <aside class="aside">
+      <nav class="toc" aria-label="Содержание">
+        <h2 class="toc__title">Навигация по листу</h2>
+        <ul class="toc__list" data-toc></ul>
+      </nav>
+    </aside>
+  </div>
+</main>
+
+<script src="scripts.js"></script>
+</body>
+</html>

--- a/nemesis-claw-cheatsheet.html
+++ b/nemesis-claw-cheatsheet.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Коготь Немезиды (Nemesis Claw Cheat Sheet)</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page-nemesis-claw" data-page="nemesis-claw">
+<header class="site-header" role="banner">
+  <div class="header-inner">
+    <a class="brand" href="necron-cheatsheet.html">Kill Team HQ</a>
+    <nav class="site-nav" aria-label="Основная навигация" data-nav></nav>
+  </div>
+</header>
+<main class="page page--sheet">
+  <header class="page-hero page-hero--split">
+    <div class="page-hero__header">
+      <p class="page-hero__eyebrow">Боевой лист Kill Team</p>
+      <h1 class="page-hero__title">Коготь Немезиды</h1>
+      <p class="page-hero__lead">Элита Ночных Лордов, наводящая ужас стремительными атаками из тьмы. Шпаргалка собрана по образцу других листов Kill Team HQ и содержит переводы ключевых правил и профилей.</p>
+    </div>
+    <div class="page-hero__body">
+      <p>Все термины переведены в соответствии с глоссарием проекта; оригинальные названия указаны в скобках для удобной сверки с английскими источниками.</p>
+    </div>
+  </header>
+
+  <div class="page-layout">
+    <div class="sheet">
+      <section>
+        <h2 id="faction-rules" class="section-title">Правила фракции (Faction Rules)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="astartes" class="section-subtitle">Астартес (Astartes)</h3>
+            <p>Во время активации каждого дружеского оперативника NEMESIS CLAW он может выполнить либо две Стрельбы (Shoot), либо две Схватки (Fight). Если выбраны две Стрельбы, хотя бы одно действие должно использовать болт-пистолет (Bolt pistol), болтган (Boltgun) или прицельный болт-пистолет (Scoped bolt pistol).</p>
+            <p>Каждый дружеский оперативник NEMESIS CLAW может контратаковать (counteract) независимо от своего приказа.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="in-midnight-clad" class="section-subtitle">«В плаще ночи» (In Midnight Clad)</h3>
+            <p>Когда вражеский оперативник стреляет по дружескому оперативнику NEMESIS CLAW, тот считается скрытым (Obscured), если выполняются оба условия: цель находится дальше 8" от всех видимых ей вражеских оперативников и в пределах её зоны контроля есть тяжёлая местность (Heavy terrain) или какая-либо часть её базы находится под местностью с преимуществом высоты (Vantage terrain).</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="strategic-ploys" class="section-title">Стратегические плои (Strategy Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="we-have-come-for-you">«Мы пришли за вами» (We Have Come For You)</h3>
+            <p>Когда дружеский оперативник NEMESIS CLAW активируется и первым действием выбирает Рывок (Charge), после завершения перемещения нанесите D3 урона одному вражескому оперативнику в его зоне контроля.</p>
+          </article>
+          <article class="card">
+            <h3 id="the-black-hunt">«Чёрная охота» (The Black Hunt)</h3>
+            <p>Когда дружеский оперативник NEMESIS CLAW стреляет, сражается или контратакует раненного врага, можно перебросить один куб атаки.</p>
+          </article>
+          <article class="card">
+            <h3 id="preysight">«Чутьё на добычу» (Preysight)</h3>
+            <p>При выборе цели для дружеского оперативника NEMESIS CLAW вражеские оперативники в пределах 6" не могут использовать лёгкую местность (Light terrain) для укрытия. Это позволяет нацелиться на них (если они видимы), но не лишает возможного спасброска от укрытия.</p>
+          </article>
+          <article class="card">
+            <h3 id="return-to-darkness">«Назад во тьму» (Return to Darkness)</h3>
+            <p>Один дружеский оперативник NEMESIS CLAW немедленно выполняет бесплатное действие Отступление (Fall Back) или Перестроение (Reposition). Он должен завершить движение с тяжёлой местностью в зоне контроля либо под местностью с преимуществом высоты, не может сдвинуться более чем на 4" и не может приблизиться к врагам. В зонах типа Killzone: Gallowdark стены игнорируются при определении направления.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="firefight-ploys" class="section-title">Плои перестрелки (Firefight Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="vox-scream">«Крик вокс-усилителя» (Vox Scream)</h3>
+            <p>Используйте плой, когда соперник собирается активировать вражеского оперативника. Он не может активировать его в эту очередь. Если нет других доступных врагов, эффект отсутствует. Стоимость плоя увеличивается на 1 CP за каждое предыдущее применение в битве.</p>
+          </article>
+          <article class="card">
+            <h3 id="death-to-the-false-emperor">«Смерть Ложному Императору» (Death to the False Emperor)</h3>
+            <p>Используйте плой после броска атаки дружеского оперативника NEMESIS CLAW против цели с ключевым словом IMPERIUM. Его оружие получает правило Неумолимый (Ceaseless) до конца последовательности; если у цели также есть ключевое слово IMPERIUM ADEPTUS ASTARTES, вместо этого оружие получает правило Безжалостный (Relentless).</p>
+          </article>
+          <article class="card">
+            <h3 id="proclivity-for-murder">«Жажда убийства» (Proclivity for Murder)</h3>
+            <p>Используйте плой после того, как дружеский оперативник NEMESIS CLAW вывел из строя врага в пределах своей зоны контроля. Он немедленно выполняет бесплатный Рывок (Charge) или Бросок (Dash); при выборе Рывка перемещение ограничено 3".</p>
+          </article>
+          <article class="card">
+            <h3 id="dirty-fighter">«Бей исподтишка» (Dirty Fighter)</h3>
+            <p>Используйте плой, когда дружеский оперативник NEMESIS CLAW контратакует (retaliate) — в начале шага «Разрешение кубов атаки» (Resolve Attack Dice). Разрешите один свой успех до обычного порядка; если так сделано, другие успехи в этой последовательности использовать нельзя.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-equipment" class="section-title">Снаряжение фракции (Faction Equipment)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="flayed-skin">Содранная кожа (Flayed Skin)</h3>
+            <p>Когда враг стреляет, сражается или контратакует дружеского оперативника NEMESIS CLAW в пределах 2", он не может перебрасывать результаты 1 на кубах атаки.</p>
+          </article>
+          <article class="card">
+            <h3 id="chain-snare">Цепные тенёта (Chain Snare)</h3>
+            <p>Когда вражеский оперативник пытается выполнить Отступление (Fall Back), находясь в зоне контроля дружеского оперативника NEMESIS CLAW без других врагов в этой зоне, можно бросить два D6 (или один D6, если у цели больше ран (Wounds)). При результате 4+ Отступление отменяется и не тратит AP.</p>
+          </article>
+          <article class="card">
+            <h3 id="grisly-trophy">Жуткий трофей (Grisly Trophy)</h3>
+            <p>Раз за битву, когда дружеский оперативник NEMESIS CLAW выводит врага из строя в пределах 2", можно дать ему ваш жетон «Жуткий трофей». Пока такой оперативник видим и находится в пределах 2" от врага, у оружия противника на 1 меньше атаки (Atk).</p>
+          </article>
+          <article class="card">
+            <h3 id="comms-jammers">Глушители связи (Comms Jammers)</h3>
+            <p>Вражеские оперативники в пределах 3" от дружеского оперативника NEMESIS CLAW не могут увеличивать свою характеристику действий (APL). Уже применённые изменения не затрагиваются.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="datacards" class="section-title">Датакарты (Datacards)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="night-lord-visionary">Ночной Лорд-провидец (Night Lord Visionary)</h3>
+            <p>Страшный лидер отряда читает судьбу своих бойцов и врагов, используя предвидение, чтобы разить в нужный момент.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">15</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменный пистолет (обычный режим) (Plasma pistol, standard)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменный пистолет (перегрев) (Plasma pistol, supercharge)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Горячий (Hot), Смертельный 5+ (Lethal 5+), Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ностраманский цепной клинок (Nostraman chainblade)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Рвущий (Rending)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовой кулак (Power fist)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 5/7</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовой молот (Power maul)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Шок (Shock)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовое оружие (Power weapon)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>«Предчувствие» (Prescience, PSYCHIC):</strong> в шаге Подготовки (Ready step) каждой Стратегической фазы получайте D3 очка предчувствия (Prescience points). В конце хода сбрасывайте неизрасходованные очки. Их можно тратить в фазе Перестрелки (Firefight) на следующие эффекты (каждый — не более одного раза за ход):</p>
+            <ul>
+              <li><strong>«Зловещее предвосхищение» (Foreboding):</strong> когда приходит ваша очередь активировать оперативника, можно потратить 1 очко, чтобы пропустить активацию.</li>
+              <li><strong>«Предзнаменование» (Portent):</strong> когда куб атаки наносит обычный урон (Normal Dmg) этому оперативнику, потратьте 1 очко, чтобы игнорировать этот урон.</li>
+            </ul>
+            <p>Если оперативник выведен из строя, он не получает и не тратит очки предчувствия.</p>
+            <p><strong>«Пророчество» (Premonition, 1AP, PSYCHIC):</strong> потратьте 1 очко предчувствия, чтобы получить 1 CP. Нельзя выполнять действие более одного раза за ход и находясь в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, PSYKER, LEADER, VISIONARY. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-fearmonger">Ночной Лорд-пугач (Night Lord Fearmonger)</h3>
+            <p>Мастер ядов и токсинов, превращающий поле боя в зону кошмаров и оставляющий врагов умирать в агонии.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Прицельный болт-пистолет (короткая дистанция) (Scoped bolt pistol, short range)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Смертельный 5+ (Lethal 5+)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Прицельный болт-пистолет (дальняя дистанция) (Scoped bolt pistol, long range)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Флакон террора (Terrorchem vial)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 2/0</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Взрыв 2" (Blast 2"), Разрушительный 3 (Devastating 3), Ограниченный 1 (Limited 1), Насыщение (Saturate), Терротоксин (Terrorchem*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ядовитый клинок (Tainted blade)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Терротоксин (Terrorchem*)</div>
+              </div>
+            </div>
+            <p><em>* Терротоксин (Terrorchem):</em> в шаге «Разрешение кубов атаки», если нанесён урон критическим успехом, цель получает ваш жетон терротоксина до конца своей следующей активации, пока жива или пока оружие не использовано снова.</p>
+            <p><strong>«Яд мучительных вздохов» (Terrorchem Poison):</strong> когда оперативник с вашим жетоном терротоксина активируется, нанесите ему D3 урона.</p>
+            <p><strong>«Отравить трофей» (Poison Objective, 1AP):</strong> выберите маркер цели, который контролирует этот оперативник, и дайте ему ваш жетон терротоксина (если враг не контролирует маркер и жетона ещё нет). Когда маркер впервые попадает в зону контроля вражеского оперативника без вашего жетона, он получает жетон и после действия получает 2D3 урона. Нельзя выполнять действие в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, FEARMONGER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-gunner">Ночной Лорд-стрелок (Night Lord Gunner)</h3>
+            <p>Уничтожает цели потоками пламени или раскалённой плазмой, сея страх в рядах врага.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Огнемёт (Flamer)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 2+ • УРОН 3/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Насыщение (Saturate), Струя 2" (Torrent 2")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Мельта-ружьё (Meltagun)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 6/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Разрушительный 4 (Devastating 4), Пробитие 2 (Piercing 2)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменная пушка (обычный режим) (Plasma gun, standard)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Плазменная пушка (перегрев) (Plasma gun, supercharge)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Горячий (Hot), Смертельный 5+ (Lethal 5+), Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, GUNNER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-heavy-gunner">Ночной Лорд-тяжёлый стрелок (Night Lord Heavy Gunner)</h3>
+            <p>Поливает врагов бурями болтов или разрывает их ракетами, подавляя любую оборону.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Тяжёлый болтер (точный огонь) (Heavy bolter, focused)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Пробитие крита 1 (Piercing Crits 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Тяжёлый болтер (заградительный огонь) (Heavy bolter, sweeping)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Пробитие крита 1 (Piercing Crits 1), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетная установка (осколочные) (Missile launcher, frag)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 2" (Blast 2"), Тяжёлый (Heavy, только Reposition)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетная установка (бронебойные) (Missile launcher, krak)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 5/7</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, HEAVY GUNNER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-screecher">Ночной Лорд-визгун (Night Lord Screecher)</h3>
+            <p>Издаёт ужасающие вопли, парализующие врагов страхом и открывающие их для молниеносных ударов.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Молниевые когти (Lightning claws)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Неумолимый (Ceaseless), Смертельный 5+ (Lethal 5+)</div>
+              </div>
+            </div>
+            <p><strong>«Визгун» (Screecher):</strong> вражеские оперативники в пределах 3" не могут перебрасывать кубы атаки при стрельбе, схватке или контратаке.</p>
+            <p><strong>«Жажда жестокости» (Appetite for Cruelty):</strong> когда этот оперативник сражается с раненным врагом, его молниевые когти получают правило Смертельный 4+ (Lethal 4+).</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, SCREECHER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-skinthief">Ночной Лорд-кожекрад (Night Lord Skinthief)</h3>
+            <p>Карает добычу ностраманской цепной глефой, внушая ужас всем, кто видит его кровавые трофеи.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ностраманская цепноглефа (Nostraman chainglaive)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Рвущий (Rending)</div>
+              </div>
+            </div>
+            <p><strong>«Содрать заживо» (Flay Them Alive):</strong> раз за ход, когда этот оперативник выводит врага из строя в своей зоне контроля, выберите другого врага в пределах 6" и в линии видимости его или поверженной цели. До начала следующего хода он не может контролировать маркеры или выполнять действия Pick Up Marker и миссионные действия.</p>
+            <p><strong>«Тиран кожевников» (Tyrant of the Skinning Pits):</strong> когда оперативник сражается или контратакует, обычный и критический урон 3+ по нему уменьшается на 1.</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, SKINTHIEF. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-ventrilokar">Ночной Лорд-вентрилокар (Night Lord Ventrilokar)</h3>
+            <p>Использует ужасающее устройство «пожиратель голоса», чтобы посеять панику, имитируя крики жертв.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Цепной меч (Chainsword)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Знаменосец (Icon Bearer):</strong> при определении контроля маркера считайте характеристику действий (APL) этого оперативника на 1 выше (это не изменение характеристики, поэтому складывается с другими эффектами).</p>
+            <p><strong>«Тревожное подражание» (Disconcerting Mimicry, 1AP, PSYCHIC):</strong> выберите вражеского оперативника в пределах 6". Один из следующих эффектов применяется к нему (каждый вариант можно выбрать лишь один раз за битву): уменьшите его APL на 1 до конца следующей активации; смените его приказ; выполните его бесплатный Бросок (Dash), указав сопернику конечную позицию. Нельзя выполнять действие в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, PSYKER, VENTRILOKAR. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="night-lord-warrior">Ночной Лорд-воин (Night Lord Warrior)</h3>
+            <p>Основная ударная сила, комбинирующая огневую мощь и беспощадные атаки в ближнем бою.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болт-пистолет (Bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Болтган (Boltgun)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Цепной меч (Chainsword)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Жестокий мучитель» (Cruel Tormenter):</strong> когда оперативник стреляет, сражается или контратакует раненого врага или врага с 7 ранами и меньше, его оружие получает правило Смертельный 5+ (Lethal 5+).</p>
+            <p><strong>Ключевые слова:</strong> NEMESIS CLAW, CHAOS, HERETIC ASTARTES, WARRIOR. Основание ⌀32 мм.</p>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <nav class="page-nav" aria-label="Навигация по листу" data-page-toc data-toc-scope=".sheet" data-toc-target=".section-title, .cards .card h3" data-toc-prefix="nemesis-claw" data-toc-levels=".section-title:2; .cards .card h3:3">
+      <h2>Разделы</h2>
+      <ul class="page-nav-list" data-page-toc-list></ul>
+    </nav>
+  </div>
+</main>
+<script src="scripts.js" defer></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -36,6 +36,18 @@ const KILL_TEAM_LIBRARY = [
     focus: ['Стрельба', 'Поддержка', 'Маркерсветы']
   },
   {
+    key: 'elucidian-starstriders',
+    name: 'Элусидианские Старстрайдеры',
+    originalName: 'Elucidian Starstriders',
+    faction: 'Империум',
+    alignment: 'Империум',
+    href: 'elucidian-starstriders-cheatsheet.html',
+    status: 'available',
+    navLabel: 'Элусидианские Старстрайдеры (Elucidian Starstriders)',
+    summary: 'Килл-тим вольного торговца с упором на гибкие сделки и орбитальную поддержку.',
+    focus: ['Стрельба', 'Поддержка', 'Манёвры']
+  },
+  {
     key: 'adepta-sororitas-novitiate',
     name: 'Новициаты Сороритас ',
     originalName: 'Adepta Sororitas Novitiate',
@@ -60,6 +72,30 @@ const KILL_TEAM_LIBRARY = [
     focus: ['Стойкость', 'Рукопашный бой', 'Зоны заражения']
   },
   {
+    key: 'warpcoven',
+    name: 'Варпковен',
+    originalName: 'Warp Coven',
+    faction: 'Тысяча Сынов',
+    alignment: 'Хаос',
+    href: 'warpcoven-cheatsheet.html',
+    status: 'available',
+    navLabel: 'Варпковен (Warp Coven)',
+    summary: 'Ковен колдунов Тысячи Сынов, сочетающий псионику рубриков и натиск тзаангоров.',
+    focus: ['Псионика', 'Стрельба', 'Контроль']
+  },
+  {
+    key: 'nemesis-claw',
+    name: 'Коготь Немезиды',
+    originalName: 'Nemesis Claw',
+    faction: 'Ночные Лорды',
+    alignment: 'Хаос',
+    href: 'nemesis-claw-cheatsheet.html',
+    status: 'available',
+    navLabel: 'Коготь Немезиды (Nemesis Claw)',
+    summary: 'Культ Ночных Лордов, сочетающий удары из тьмы, давление страхом и гибкое применение Астартес-приёмов.',
+    focus: ['Рукопашный бой', 'Психологическое давление', 'Манёвренность']
+  },
+  {
     key: 'kommandos',
     name: 'Коммандосы',
     originalName: 'Kommandos',
@@ -70,6 +106,30 @@ const KILL_TEAM_LIBRARY = [
     navLabel: 'Коммандосы (Kommandos)',
     summary: 'Грубые, но изобретательные орки-диверсанты с упором на скрытность.',
     focus: ['Маскировка', 'Взрывы', 'Рукопашный бой']
+  },
+  {
+    key: 'wrecka-krew',
+    name: 'Разносчики',
+    originalName: 'Wrecka Krew',
+    faction: 'Орки',
+    alignment: 'Ксенос',
+    href: 'wrecka-krew-cheatsheet.html',
+    status: 'available',
+    navLabel: 'Разносчики (Wrecka Krew)',
+    summary: 'Орочий отряд танкоубийц, накапливающих очки «Разгрома» и усиливающих взрывы.',
+    focus: ['Взрывы', 'Рукопашный бой', 'Синергия очков']
+  },
+  {
+    key: 'hearthkyn-salvagers',
+    name: 'Хэрткин-спасатели',
+    originalName: 'Hearthkyn Salvagers',
+    faction: 'Лиги Вотан',
+    alignment: 'Ксенос',
+    href: 'hearthkyn-salvagers-cheatsheet.html',
+    status: 'available',
+    navLabel: 'Хэрткин-спасатели (Hearthkyn Salvagers)',
+    summary: 'Команда спасателей Лиг Вотан, полагающаяся на жетоны «обиды» и усиление ближнего боя.',
+    focus: ['Стойкость', 'Синергия жетонов', 'Контроль целей']
   },
   {
     key: 'inquisitorial-agents',

--- a/warpcoven-cheatsheet.html
+++ b/warpcoven-cheatsheet.html
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Варпковен (Warp Coven Cheat Sheet)</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page-warpcoven" data-page="warpcoven">
+<header class="site-header" role="banner">
+  <div class="header-inner">
+    <a class="brand" href="necron-cheatsheet.html">Kill Team HQ</a>
+    <nav class="site-nav" aria-label="Основная навигация" data-nav></nav>
+  </div>
+</header>
+<main class="page page--sheet">
+  <header class="page-hero page-hero--split">
+    <div class="page-hero__header">
+      <p class="page-hero__eyebrow">Боевой лист Kill Team</p>
+      <h1 class="page-hero__title">Варпковен</h1>
+      <p class="page-hero__lead">Колдуны Тысячи Сынов ведут в бой рубриков и тзаангоров, насыщая поле сражения псионическим пламенем и изломанной судьбой.</p>
+    </div>
+    <div class="page-hero__body">
+      <p>Переводы согласованы с глоссарием Kill Team HQ: ключевые названия снабжены оригиналом в скобках, а структура страницы идентична другим шпаргалкам для корректной работы навигационных скриптов.</p>
+    </div>
+  </header>
+
+  <div class="page-layout">
+    <div class="sheet">
+      <section>
+        <h2 id="team-overview" class="section-title">Состав и архетипы (Kill Team Roster)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="warpcoven-kill-team">Команда Warpcoven</h3>
+            <p><strong>Архетипы:</strong> Безопасность / Разведка (Archetype: Security / Recon).</p>
+            <p>Соберите килл-тим из 6 оперативников WARPCOVEN, выбирая из списка ниже. Вы обязаны включить минимум одного оперативника SORCERER, и один из выбранных колдунов должен иметь ключевое слово LEADER — его запас ран (Wounds) увеличивается на 1 на время битвы. Кроме оперативников WARRIOR и GUNNER, каждую позицию можно взять только один раз. В команде допускается не более двух GUNNER.</p>
+            <ul>
+              <li>SORCERER DESTINY<sup>1</sup></li>
+              <li>SORCERER TEMPYRION<sup>1</sup></li>
+              <li>SORCERER WARPFIRE<sup>1</sup></li>
+              <li>RUBRIC MARINE GUNNER с одним из вариантов: варппламер (Warpflamer); душекосный канон (Soulreaper cannon)<sup>2</sup>; кулаки (fists)</li>
+              <li>RUBRIC MARINE ICON BEARER</li>
+              <li>RUBRIC MARINE WARRIOR</li>
+              <li>TZAANGOR CHAMPION<sup>3</sup> с двуручным топором (Greataxe) или двуручным клинком (Greatblade)</li>
+              <li>TZAANGOR HORN BEARER<sup>3</sup></li>
+              <li>TZAANGOR ICON BEARER<sup>3</sup></li>
+              <li>TZAANGOR WARRIOR<sup>3</sup> с одним из вариантов: парные клинки тзаангоров (Tzaangor blades); клинок и щит тзаангоров (Tzaangor blade &amp; shield); автопистолет и цепной меч (Autopistol; chainsword)</li>
+            </ul>
+            <p><sup>1</sup> Каждый оперативник SORCERER вооружён силовым посохом (force stave), псионическим оружием (PSYCHIC weapons) с его дата-карты и одним из вариантов: инферно-болт-пистолет (Inferno bolt pistol), просперинский копеш (Prosperine khopesh) или варппламенный пистолет (Warpflame pistol)<sup>2</sup>.</p>
+            <p><sup>2</sup> В килл-тиме может быть не более одного варппламенного пистолета и одного душекосного канона. <sup>3</sup> Эти оперативники считаются половиной выбора: можно включить обе позиции, и это считается одним выбором.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-rules" class="section-title">Правила фракции (Faction Rules)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="boons-of-tzeentch">Дары Тзинча (Boons of Tzeentch)</h3>
+            <p>Каждый выбранный оперативник SORCERER получает один дар Тзинча (BOON OF TZEENTCH) на битву. Нельзя выбирать один и тот же дар более одного раза. Доступные дары:</p>
+            <ul>
+              <li><strong>«Бестелесное зрение» (Incorporeal Sight):</strong> дальнобойное оружие получает правило Насыщение (Saturate), а цели не могут быть скрытыми (Obscured), когда этот оперативник стреляет.</li>
+              <li><strong>«Шаг сквозь время» (Time-Walk):</strong> добавьте 1" к характеристике Движение (Move).</li>
+              <li><strong>«Эхо Варпа» (Echoes from the Warp):</strong> раз за битву, когда этот оперативник контратакует (counteract), вы можете сменить ему приказ и выполнить дополнительное бесплатное действие стоимостью 1 AP, отличное от первого.</li>
+              <li><strong>«Вздымание Варпа» (Warp Swell):</strong> увеличьте базовый урон (Normal Dmg) оружия ближнего боя на 1.</li>
+              <li><strong>«Мутационный придаток» (Mutant Appendage):</strong> присутствие врага в зоне контроля не мешает выполнять действия «Поднять маркер» (Pick Up Marker) и миссионные действия. Раз за активацию можно выполнить Pick Up Marker, Place Marker или миссионное действие на 1 AP дешевле.</li>
+              <li><strong>«Бестелесный полёт» (Immaterial Flight):</strong> раз за ход при выполнении действий Рывок (Charge) или Перестроение (Reposition) этот оперативник может получить FLY: вместо перемещения снимите его с поля и установите полностью в пределах расстояния его характеристики Move по горизонтали. В закрытых зонах (например, Killzone: Gallowdark) нельзя измерять сквозь стены и ставить его через люки. Он должен оказаться в допустимом месте и, кроме действия Charge, не может завершить перемещение в зоне контроля врага.</li>
+              <li><strong>«Искажение судьбы» (Twist of Fate):</strong> псионические дальнобойные оружия (PSYCHIC ranged weapons) получают правило Пробитие крита 1 (Piercing Crits 1).</li>
+              <li><strong>«Астральный обстрел» (Astral Bombardment):</strong> выберите одно псионическое дальнобойное оружие. Оно получает правило Разрушительный 1 (Devastating 1). Если выбрано «Смертельный взгляд» (Doombolt), оружие вместо этого получает правило Разрушительный 2" (Devastating 2"). Если выбрано «Огненная буря» (Firestorm) или «Выжигание разума» (Mindburn, SORCERER WARPFIRE), каждый раз при выполнении действия Стрельба (Shoot) выберите для него правило «Искать свет» (Seek Light) или Разрушительный 1 (Devastating 1) до конца действия (нельзя выбрать оба).</li>
+              <li><strong>«Хозяин Иматериума» (Master of the Immaterium):</strong> увеличьте на 3" все дистанции в правилах псионических действий этого оперативника, если в них указано расстояние. Для действия «Темпоральный поток» (Temporal Flux) у SORCERER TEMPYRION увеличивается только дальность первого эффекта.</li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <h3 id="astartes">Астартес (Astartes)</h3>
+            <p>Каждый дружеский оперативник HERETIC ASTARTES во время своей активации может выполнить две Стрельбы (Shoot) или две Схватки (Fight). Если это две Стрельбы и для обеих выбран душекосный канон (Soulreaper cannon) или варппламер (Warpflamer), за второе действие требуется заплатить дополнительное очко действия (AP). Нельзя выбирать одно и то же псионическое дальнобойное оружие (PSYCHIC ranged weapon) более одного раза за активацию.</p>
+            <p>Каждый дружеский оперативник WARPCOVEN HERETIC ASTARTES может контратаковать (counteract) независимо от своего приказа.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="strategic-ploys" class="section-title">Стратегические плои (Strategy Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="aetherial-warding">Эфирное преграждение (Aetherial Warding)</h3>
+            <p>Когда враг стреляет по дружескому оперативнику WARPCOVEN, оружие с правилом Пробитие 1 (Piercing 1) вместо этого получает правило Пробитие крита 1 (Piercing Crits 1).</p>
+          </article>
+          <article class="card">
+            <h3 id="fate-itself-is-my-weapon">«Судьба — моё оружие» (Fate Itself Is My Weapon)</h3>
+            <p>Бросьте два D6 и отложите результаты. В следующей фазе Перестрелки (Firefight phase), когда любой оперативник стреляет, сражается или контратакует, после броска кубов атаки (до перебросов) вы можете заменить один из бросков (ваш или соперника) одним из отложенных кубов. Этот куб нельзя перебрасывать или считать успехом, если он им не является, и он сбрасывается в конце последовательности. Если сумма обоих отложенных кубов меньше 9, второй куб сразу сбрасывается. Нельзя использовать более одного отложенного куба в одной последовательности. Все неиспользованные кубы сбрасываются в конце игрового хода.</p>
+          </article>
+          <article class="card">
+            <h3 id="brotherhood-of-sorcerers">Братство колдунов (Brotherhood of Sorcerers)</h3>
+            <p>Когда дружеский оперативник WARPCOVEN SORCERER находится в пределах 9" от другого дружеского SORCERER, его псионическое дальнобойное оружие (PSYCHIC ranged weapon) получает правило Сбалансированный (Balanced).</p>
+          </article>
+          <article class="card">
+            <h3 id="savage-herd">Дикая стая (Savage Herd)</h3>
+            <p>Оружие ближнего боя дружеских оперативников WARPCOVEN TZAANGOR получает правило Точный 1 (Accurate 1). Если такой оперативник получает помощь (assisted) от дружеского оперативника WARPCOVEN или сражается, находясь в пределах 6" и в линии видимости дружеского SORCERER, его оружие ближнего боя также получает правило Жестокий (Severe).</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="firefight-ploys" class="section-title">Плои перестрелки (Firefight Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="all-is-dust">«Лишь пыль» (All Is Dust)</h3>
+            <p>Используйте плой, когда бросок атаки наносит обычный урон (Normal Dmg) дружескому оперативнику WARPCOVEN RUBRIC MARINE. Этот бросок наносит лишь 1 урон.</p>
+          </article>
+          <article class="card">
+            <h3 id="capricious-plan">Капризный план (Capricious Plan)</h3>
+            <p>Используйте плой в конце активации дружеского оперативника WARPCOVEN SORCERER. Этот оперативник может сразу выполнить бесплатное действие Бросок (Dash) даже если другие эффекты это запрещают, либо вы можете сменить его приказ.</p>
+          </article>
+          <article class="card">
+            <h3 id="psychic-cabal">Псионическая кабала (Psychic Cabal)</h3>
+            <p>Используйте плой при активации дружеского оперативника WARPCOVEN SORCERER. Выберите другого дружеского SORCERER в пределах 9" и в линии видимости. Выберите одно уникальное псионическое действие (PSYCHIC unique action) или псионическое дальнобойное оружие на его дата-карте: первый оперативник получает его до конца активации. Нельзя выбирать оружие, которым второй оперативник уже пользовался в этом ходе; второй также не может использовать выбранное оружие в текущем ходе.</p>
+          </article>
+          <article class="card">
+            <h3 id="mutant-herd">Мутировавшая стая (Mutant Herd)</h3>
+            <p>Используйте плой при активации дружеского оперативника WARPCOVEN TZAANGOR. Выберите другого готового дружеского TZAANGOR в пределах 2" и в линии видимости — его можно активировать сразу же, выполняя действия попеременно в любом порядке. После расходования обоих оперативников ход переходит сопернику.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-equipment" class="section-title">Снаряжение фракции (Faction Equipment)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="ensorcelled-rounds">Зачарованные патроны (Ensorcelled Rounds)</h3>
+            <p>Инферно-болтганы, инферно-болт-пистолеты и автопистолеты дружеских оперативников WARPCOVEN получают правило Разрушительный 1 (Devastating 1).</p>
+          </article>
+          <article class="card">
+            <h3 id="daemonmaw-weapons">Оружие с демонической пастью (Daemonmaw Weapons)</h3>
+            <p>Добавьте 1 к характеристике Атаки (Attacks) оружия ближнего боя дружеских оперативников WARPCOVEN RUBRIC MARINE. Когда такой оперативник контратакует (retaliates), его оружие ближнего боя также получает правило Точный 1 (Accurate 1).</p>
+          </article>
+          <article class="card">
+            <h3 id="arcane-robes">Арканные одеяния (Arcane Robes)</h3>
+            <p>Раз за игровой ход, когда бросок атаки должен нанести критический урон (Critical Dmg) дружескому оперативнику WARPCOVEN SORCERER, можно применить это правило: вместо критического урона бросок наносит обычный урон.</p>
+          </article>
+          <article class="card">
+            <h3 id="sorcerous-scrolls">Колдовские свитки (Sorcerous Scrolls)</h3>
+            <p>Раз за битву, когда дружеский оперативник WARPCOVEN SORCERER активируется или контратакует, выберите новый дар Тзинча (BOON OF TZEENTCH) для него до конца битвы (предыдущие теряются). Нельзя выбрать дар, который уже есть у другого дружеского оперативника. Если вы выбираете «Эхо Варпа» (Echoes from the Warp) во время контратаки, можно сразу сменить приказ и выполнить бесплатное действие.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="datacards" class="section-title">Датакарты (Datacards)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="sorcerer-destiny">Колдун судьбы (Sorcerer of Destiny)</h3>
+            <p>Колдуны командуют рубриками как марионетками, направляя их искажённой волей Тзинча. Носитель судьбы разрушает врагов смертоносными лучами и проклятиями.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Смертельный взгляд (Doombolt)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/2</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Разрушительный 2 (Devastating 2), Смертельный 5+ (Lethal 5+)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Инферно-болт-пистолет (Inferno bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Варппламенный пистолет (Warpflame pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 2+ • УРОН 3/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Пробитие 1 (Piercing 1), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовой посох (Force stave)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Шок (Shock)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Просперинский копеш (Prosperine khopesh)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Сбалансированный (Balanced)</div>
+              </div>
+            </div>
+            <p><strong>«Защита судьбой» (Protected by Fate, 1AP, PSYCHIC):</strong> выберите дружеского оперативника WARPCOVEN в линии видимости. До начала следующей активации этого колдуна, пока цель жива и действие не повторено, при стрельбе по ней вы можете перебросить любое количество кубов защиты.</p>
+            <p><strong>«Расторгнуть судьбу» (Ravage Destiny, 1AP, PSYCHIC):</strong> выберите вражеского оперативника в пределах 9" и в линии видимости. До следующей активации этого колдуна, пока действие не повторено и цель жива, соперник обязан перебрасывать результаты 6 на кубах атаки при стрельбе, сражении и контратаке этой целью; при определении контроля маркеров считайте её характеристику действий (APL) на 1 меньше (это не изменение характеристики).</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, PSYKER, SORCERER, DESTINY. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="sorcerer-tempyrion">Колдун Темпириона (Sorcerer of Tempyrion)</h3>
+            <p>Мастер временных потоков исцеляет воинов и перемещает их через разрывы реальности, действуя как щит и копьё ковена.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Флюксовый залп (Fluxblast)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Взрыв 2" (Blast 2"), Рвущий (Rending)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Инферно-болт-пистолет (Inferno bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Варппламенный пистолет (Warpflame pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 2+ • УРОН 3/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Пробитие 1 (Piercing 1), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовой посох (Force stave)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Шок (Shock)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Просперинский копеш (Prosperine khopesh)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Сбалансированный (Balanced)</div>
+              </div>
+            </div>
+            <p><strong>«Ритуал восстановления» (Reconstitution Ritual, 1AP, PSYCHIC):</strong> выберите дружеского оперативника WARPCOVEN в линии видимости и в пределах 6". Он восстанавливает до 2D3 потерянных ран. Нельзя выполнять действие, если оно уже применялось дружеским оперативником в текущем ходе.</p>
+            <p><strong>«Темпоральный поток» (Temporal Flux, 1AP, PSYCHIC):</strong> выберите дружеского оперативника WARPCOVEN в линии видимости и в пределах 6" и разместите маркер «Темпоральный поток» (Temporal Flux marker) в его зоне контроля. В конце следующей активации цели, если она жива и полностью в пределах 6" от маркера, уберите её с поля и установите в допустимой точке так, чтобы маркер находился в её зоне контроля, затем удалите маркер. Если к концу активации условия не выполнены (или оперативник выведен из строя), маркер просто удаляется. Нельзя использовать действие, если маркер уже на поле.</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, PSYKER, SORCERER, TEMPYRION. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="sorcerer-warpfire">Колдун Варппламени (Sorcerer of Warpfire)</h3>
+            <p>Владыка варп-пламени превращает врагов в пылающие факелы и выжигает их разум, насылая безумие и хаос.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Огненная буря (Firestorm)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Насыщение (Saturate), «Искать свет» (Seek Light), Струя 2" (Torrent 2")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Инферно-болт-пистолет (Inferno bolt pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Выжигание разума (Mindburn)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 4+ • УРОН 1/1</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Смертельный 5+ (Lethal 5+), Насыщение (Saturate), «Искать свет» (Seek Light), «Выжигание разума» (Mindburn*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Варппламенный пистолет (Warpflame pistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 2+ • УРОН 3/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 6", Пробитие 1 (Piercing 1), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Силовой посох (Force stave)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Псионика (PSYCHIC), Шок (Shock)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Просперинский копеш (Prosperine khopesh)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Сбалансированный (Balanced)</div>
+              </div>
+            </div>
+            <p><em>* «Выжигание разума» (Mindburn):</em> в шаге «Разрешение кубов атаки» (Resolve Attack Dice), если вы наносите урон критическими успехами, цель получает ваш жетон «Выжигание разума» до конца своей следующей активации, пока жива или пока оружие не используется вновь. Пока жетон активен, характеристика Попадание (Hit) её оружия ухудшается на 1 (не складывается с состоянием ранения).</p>
+            <p><strong>«Вспыхни!» (Alight, 1AP, PSYCHIC):</strong> выберите вражеского оперативника в линии видимости. До следующей активации колдуна, пока цель жива и действие не повторено, она имеет ваш жетон «Воспламенён» (Alight). Когда дружеский оперативник WARPCOVEN стреляет, сражается или контратакует против цели с этим жетоном, его оружие получает правило Неумолимый (Ceaseless).</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, PSYKER, SORCERER, WARPFIRE. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="rubric-marine-gunner">Рубрик-марин оружейник (Rubric Marine Gunner)</h3>
+            <p>Закованные в руны доспехи удерживают тяжёлые орудия, выплёвывая потоки варп-пламени и раскалённых снарядов.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Душекосный канон, точечный огонь (Soulreaper cannon, focused)</span>
+                  <span class="weapon-profile">АТК 5 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Душекосный канон, веерный огонь (Soulreaper cannon, sweeping)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1), Струя 1" (Torrent 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Варппламер (Warpflamer)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 2+ • УРОН 4/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Насыщение (Saturate), Пробитие 1 (Piercing 1), Струя 2" (Torrent 2")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Колдовской автоматон» (Sorcerous Automata):</strong> когда оперативник активируется, уменьшите его APL на 1 до конца активации, если в пределах 9" нет дружеского WARPCOVEN SORCERER.</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, RUBRIC MARINE, GUNNER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="rubric-icon-bearer">Рубрик-марин знаменосец (Rubric Marine Icon Bearer)</h3>
+            <p>Носитель икон обращает силу Тзинча в защитные чары, усиливая союзников и подавляя волю врагов.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Инферно-болтган (Inferno boltgun)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Колдовской автоматон» (Sorcerous Automata):</strong> при активации уменьшите APL на 1 до конца активации, если рядом нет дружеского SORCERER в пределах 9".</p>
+            <p><strong>«Знаменосец» (Icon Bearer):</strong> при определении контроля маркера считайте APL этого оперативника на 1 выше (это не изменение характеристики, эффекты складываются).</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, RUBRIC MARINE, ICON BEARER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="rubric-warrior">Рубрик-марин воин (Rubric Marine Warrior)</h3>
+            <p>Безмолвные оболочки, наполненные варп-пылью, методично обстреливают врага инферно-болтами.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">3</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">5"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">3+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Инферно-болтган (Inferno boltgun)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Пробитие 1 (Piercing 1)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Колдовской автоматон» (Sorcerous Automata):</strong> при активации уменьшите APL на 1 до конца активации, если в пределах 9" нет дружеского SORCERER.</p>
+            <p><strong>«Медленный и целеустремлённый» (Slow and Purposeful):</strong> когда оперативник стреляет и не выполнял действия Рывок (Charge) или Перестроение (Reposition) в эту активацию (или если это контратака), его дальнобойное оружие получает правило Неумолимый (Ceaseless). После стрельбы он всё ещё может выполнить эти действия.</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, HERETIC ASTARTES, RUBRIC MARINE, WARRIOR. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tzaangor-champion">Тзаангор-чемпион (Tzaangor Champion)</h3>
+            <p>Эти зверолюди сражаются двуручным оружием, разя врагов с яростью и точностью, достойной благословения Тзинча.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">10</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Двуручный топор (Greataxe)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal), Смертельный 5+ (Lethal 5+)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Двуручный клинок (Greatblade)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Рвущий (Rending)</div>
+              </div>
+            </div>
+            <p><strong>«Свирепая жестокость» (Savage Brutality):</strong> впервые в каждую активацию, когда оперативник выполняет действие Сражение (Fight) и остаётся в строю, он может сразу выполнить ещё одно бесплатное действие Fight (цель можно выбрать заново).</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, TZAANGOR, CHAMPION. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tzaangor-horn-bearer">Тзаангор-рогач (Tzaangor Horn Bearer)</h3>
+            <p>Оглушительные трубные сигналы ускоряют стаю, зовя мутировавших воинов в бой.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">9</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кинжал (Dagger)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Брейрог» (Brayhorn, 0AP):</strong> до шага Подготовки (Ready step) следующей Стратегической фазы увеличьте характеристику Move дружеских оперативников WARPCOVEN TZAANGOR на 1". Нельзя выполнять действие, находясь в зоне контроля врага.</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, TZAANGOR, HORN BEARER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tzaangor-icon-bearer">Тзаангор-знаменосец (Tzaangor Icon Bearer)</h3>
+            <p>Священные хоругви тзаангоров привлекают внимание Тзинча, одаривая стаю непостоянными благословениями.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">9</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кинжал (Dagger)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>«Хоругвь стаи» (Herd Banner):</strong> когда бросок атаки наносит обычный урон 3+ дружескому оперативнику WARPCOVEN TZAANGOR в пределах 3" и в линии видимости знаменосца, уменьшите нанесённый урон на 1.</p>
+            <p><strong>«Знаменосец» (Icon Bearer):</strong> считайте APL этого оперативника на 1 выше при определении контроля маркеров (эффекты складываются).</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, TZAANGOR, ICON BEARER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tzaangor-warrior">Тзаангор-воин (Tzaangor Warrior)</h3>
+            <p>Мутировавшие служители Тзинча рвутся в бой с ритуальными клинками, щитами и цепным оружием.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">9</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Автопистолет (Autopistol)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 2/3</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8"</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Цепной меч (Chainsword)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Клинок и щит тзаангоров (Tzaangor blade &amp; shield)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Щит (Shield*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Парные клинки тзаангоров (Tzaangor blades)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Сбалансированный (Balanced)</div>
+              </div>
+            </div>
+            <p><em>*Щит (Shield):</em> оперативник имеет спасбросок 4+, а в ближнем бою каждое блокирование засчитывается как блок двух успехов.</p>
+            <p><strong>«Охотники за реликвиями» (Relic Hunters):</strong> раз за битву один дружеский WARPCOVEN TZAANGOR WARRIOR может выполнить Pick Up Marker, Place Marker или миссионное действие на 1 AP дешевле, если он находится в территории соперника.</p>
+            <p><strong>Ключевые слова:</strong> WARPCOVEN, CHAOS, TZAANGOR, WARRIOR. Основание ⌀32 мм.</p>
+          </article>
+        </div>
+      </section>
+    </div>
+  </div>
+</main>
+
+<script src="scripts.js"></script>
+</body>
+</html>

--- a/wrecka-krew-cheatsheet.html
+++ b/wrecka-krew-cheatsheet.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Команда «Разносчики» (Wrecka Krew Cheat Sheet)</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="page-wrecka-krew" data-page="wrecka-krew">
+<header class="site-header" role="banner">
+  <div class="header-inner">
+    <a class="brand" href="necron-cheatsheet.html">Kill Team HQ</a>
+    <nav class="site-nav" aria-label="Основная навигация" data-nav></nav>
+  </div>
+</header>
+<main class="page page--sheet">
+  <header class="page-hero page-hero--split">
+    <div class="page-hero__header">
+      <p class="page-hero__eyebrow">Боевой лист Kill Team</p>
+      <h1 class="page-hero__title">Команда «Разносчики»</h1>
+      <p class="page-hero__lead">Взвод орочьих подрывников, вечно требующих больше взрывчатки. Лист содержит ключевые правила, плои и профили команды Wrecka Krew.</p>
+    </div>
+    <div class="page-hero__body">
+      <p>Переводы согласованы с глоссарием Kill Team HQ: названия снабжены оригиналом в скобках, а структура страницы повторяет другие шпаргалки проекта для корректной работы скриптов навигации.</p>
+    </div>
+  </header>
+
+  <div class="page-layout">
+    <div class="sheet">
+      <section>
+        <h2 id="faction-rules" class="section-title">Правила фракции (Faction Rules)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="wrecka-rampage">Разрушительный угар (Wrecka Rampage)</h3>
+            <p>Когда дружественный оперативник WRECKA KREW стреляет, сражается или контратакует (Retaliate) в шаге броска кубов атаки (Roll Attack Dice), за каждую сохранённую шестёрку получайте 1 очко «Разгрома» (Wrecka point). Можно потратить до 3 очков (оперативники BOMB SQUIG не могут тратить очки), превращая за каждое потраченное очко один провал в обычный успех. Одновременно у вас может быть не более 6 очков. Вы можете получать и тратить очки в любом порядке во время действия, если в его начале у вас было меньше 6.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tanked-up">Заправлены по крышку (Tanked Up)</h3>
+            <p>Когда дружественный оперативник WRECKA KREW (кроме BOMB SQUIG) с приказом Атака (Engage order) выполняет действие Стрельба (Shoot) или Сражение (Fight), до начала его следующей активации увеличьте характеристику действий (APL) на 1.</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="strategic-ploys" class="section-title">Стратегические плои (Strategy Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="waaagh">«Вааагх!» (WAAAGH!)</h3>
+            <p>Дружественное оружие ближнего боя оперативников WRECKA KREW получает правило Сбалансированный (Balanced).</p>
+          </article>
+          <article class="card">
+            <h3 id="destruction">«Разрушение» (Destruction)</h3>
+            <p>Дальнобойное оружие дружественных оперативников WRECKA KREW получает правило Насыщение (Saturate).</p>
+          </article>
+          <article class="card">
+            <h3 id="tuff-gitz">«Крепкосмешные» (Tuff Gitz)</h3>
+            <p>Когда враг стреляет по дружественному оперативнику WRECKA KREW с приказом Атака (Engage order), перебросьте один куб спасброска.</p>
+          </article>
+          <article class="card">
+            <h3 id="amped-up">«На адреналине» (Amped Up)</h3>
+            <p>Каждый дружественный оперативник WRECKA KREW с приказом Атака (Engage order) немедленно восстанавливает до D3+1 потерянных ран (бросок отдельно для каждого оперативника).</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="firefight-ploys" class="section-title">Плои перестрелки (Firefight Ploys)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="just-a-scratch">«Пустяковая царапина» (Just a Scratch)</h3>
+            <p>Используйте плой, когда обычный урон наносится дружественному оперативнику WRECKA KREW (кроме BOMB SQUIG). Игнорируйте этот урон.</p>
+          </article>
+          <article class="card">
+            <h3 id="proppa-scrap">«Знатная драка» (Proppa Scrap)</h3>
+            <p>Используйте плой во время активации дружественного оперативника BREAKA BOY или BOSS NOB. В эту активацию он может выполнить два действия Сражение (Fight).</p>
+          </article>
+          <article class="card">
+            <h3 id="demolition-job">«Подрывное дело» (Demolition Job)</h3>
+            <p>Используйте плой после того, как дружественный оперативник WRECKA KREW завершит действие Стрельба (Shoot) или Сражение (Fight), перед тем как удалить выведенных из строя оперативников. Поместите свой маркер «Подрыв» (Demolition marker) в зону контроля цели (для оружия с правилом Взрыв (Blast) — первичной цели). Пока дружественный оперативник WRECKA KREW (кроме BOMB SQUIG) стреляет, сражается или контратакует цель в пределах 3" от маркера, вы можете потратить одно очко «Разгрома» бесплатно (даже если у вас их нет). В шаге Подготовки (Ready step) следующей Стратегической фазы удалите маркер.</p>
+          </article>
+          <article class="card">
+            <h3 id="kaboom">«БА-БАХ!» (Kaboom!)</h3>
+            <p>Используйте плой, когда дружественный оперативник WRECKA KREW выполняет действие Стрельба (Shoot) оружием с правилом Взрыв (Blast). До конца действия увеличьте радиус Взрыва на 1" и дайте оружию правило Жестокий (Severe) против первичной цели. Нельзя применять вместе с правилом «Буровые ракеты» (Drill Rokkits) для того же действия. Правило Severe не приносит очки «Разгрома».</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="faction-equipment" class="section-title">Снаряжение фракции (Faction Equipment)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="drill-rokkits">Буровые ракеты (Drill Rokkits)</h3>
+            <p>Раз за игровой ход (turning point), когда дружественный оперативник WRECKA KREW выполняет действие Стрельба (Shoot), выбирая ракетомёт (rokkit launcha) или тяжёлый ракетомёт (’eavy rokkit launcha), можете применить это правило: до конца действия оружие теряет правило Взрыв (Blast), но получает Пробитие 1 (Piercing 1).</p>
+          </article>
+          <article class="card">
+            <h3 id="engine-oil">Моторное масло (Engine Oil)</h3>
+            <p>Раз за игровой ход (turning point), когда активируется дружественный оперативник WRECKA KREW (кроме BOMB SQUIG), примените правило: до конца активации игнорируйте изменения характеристик от состояния ранения.</p>
+          </article>
+          <article class="card">
+            <h3 id="extra-armour">Дополнительная броня (Extra Armour)</h3>
+            <p>Уменьшите характеристику Движение (Move) дружественных оперативников WRECKA KREW на 1", но увеличьте их количество ран (Wounds) на 1. BOMB SQUIG не затрагиваются.</p>
+          </article>
+          <article class="card">
+            <h3 id="glyphs">Глифы (Glyphs)</h3>
+            <p>При выборе этого снаряжения также выберите стратегический плой «Вааагх!» (WAAAGH!) или «Разрушение» (Destruction). Первый раз в битве этот плой стоит 0 CP; затем он стоит 0 CP, если у вас есть хотя бы одно очко «Разгрома».</p>
+          </article>
+        </div>
+      </section>
+
+      <hr class="section-divider">
+
+      <section>
+        <h2 id="datacards" class="section-title">Датакарты (Datacards)</h2>
+        <div class="cards">
+          <article class="card">
+            <h3 id="wrecka-boss-nob">Босс-Ноб Разносчиков (Wrecka Boss Nob)</h3>
+            <p>Самый сильный и безжалостный Танкоубийца или Разрушитель ведёт отряд в бой. Только настоящий громила способен удержать «мальчишек» от погонь за случайными целями.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">14</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетный пистолет (Rokkit pistol)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Взрыв 1" (Blast 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Два ракетных пистолета, сосредоточенный режим (Two rokkit pistols, focused)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Взрыв 1" (Blast 1"), Неумолимый (Ceaseless)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Два ракетных пистолета, залповый режим (Two rokkit pistols, salvo)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Дальность 8", Взрыв 1" (Blast 1"), Залп (Salvo*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Чоппа (Choppa)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кувалда (Smash hammer)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal)</div>
+              </div>
+            </div>
+            <p><strong>Босс Разносчиков (Wrecka Boss):</strong> когда этот оперативник выполняет действие Стрельба (Shoot) или Сражение (Fight), получайте 1 очко «Разгрома».</p>
+            <p><strong>Залп (Salvo):</strong> выберите до двух различных допустимых целей, не находящихся в зоне контроля дружественных оперативников. Стреляйте по каждой первичной цели в любом порядке, затем по оставшимся вторичным целям (каждую последовательность бросайте отдельно). Ни одна цель не может быть обстреляна более одного раза за действие.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, LEADER, BOSS NOB. Основание ⌀40 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="wrecka-bomb-squig">Бомбосквиг Разносчиков (Wrecka Bomb Squig)</h3>
+            <p>Орки выращивают всё новых скуигов для взрывных забав. «Бомбасквигов» загоняют прямо во врага, привязывая к ним заряд.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">5+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">5</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Взрывчатка (Explosives)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 1" (Blast 1"), Ограниченный 1 (Limited 1), Взрывчатый (Explosive*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Укус (Bite)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Взрывчатый (Explosive):</strong> оперативник может выполнить действие Стрельба (Shoot) этим оружием, находясь в зоне контроля врага. Цель не выбирается; первичной целью всегда является сам скуиг, и он не может получать укрытие или быть скрыт (Obscured).</p>
+            <p><strong>Туповатый (Stoopid):</strong> в фазе Перестрелки (Firefight phase), когда выбираете приказ, нельзя выбрать приказ Скрытность (Conceal order). Оперативник может выполнять только действия Рывок (Charge), Бросок (Dash), Сражение (Fight), Перестроение (Reposition) и Стрельба (Shoot). Нельзя использовать оружие вне дата-карты.</p>
+            <p><strong>Бум! (Boom!):</strong> если оперативник выведен из строя до использования взрывчатки, бросьте 1D6 (или 2D6 по желанию). При результате 4+ он выполняет бесплатное действие Стрельба (Shoot) взрывчаткой перед удалением из зоны боевых действий.</p>
+            <p><strong>Расходный материал (Expendable):</strong> оперативника игнорируют при расчёте целей соперника на убийство/уничтожение, при определении стартового числа оперативников, а также при проверке условий победы, связанных с выживанием или эвакуацией.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, BOMB SQUIG. Основание ⌀25 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="breaka-boy-demolisha">Разрушитель-демолиша (Breaka Boy Demolisha)</h3>
+            <p>«Демолиши» навешивают ракеты на кувалды, чтобы взрывать цель при каждом ударе. Риск для себя их волнует меньше всего.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">12</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Танкодробитель, удар (Tankhammer, bash)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Танкодробитель, подрыв (Tankhammer, detonate)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН *</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Смертельный 5+ (Lethal 5+), Ограниченный 1 (Limited 1), Подрыв (Detonate*)</div>
+              </div>
+            </div>
+            <p><strong>Безрассудный нрав (Reckless Temperament):</strong> обычный урон 4+ наносит на 1 рану меньше; если оперативник под приказом Атака (Engage order), критический урон 4+ тоже уменьшается на 1.</p>
+            <p><strong>Подрыв (Detonate):</strong> впервые за битву, когда вы наносите урон этим профилем, нанесите D6+6 урона цели и каждому оперативнику в её зоне контроля при обычном успехе, либо 2D6+6 при критическом успехе (броски отдельно). Затем действие заканчивается, и вы получаете 1 очко «Разгрома» плюс ещё по 1 за каждого выведенного из строя оперативника. Урон от этого правила нельзя предотвратить или уменьшить.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, BREAKA BOY, DEMOLISHA. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="breaka-boy-fighter">Разрушитель-боец (Breaka Boy Fighter)</h3>
+            <p>Эти орки предпочитают проламывать врагов в рукопашной, используя тяжёлые кувалды.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">12</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кувалда (Smash hammer)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal)</div>
+              </div>
+            </div>
+            <p><strong>Ломать всё (Break Stuff, 1AP):</strong> выберите элемент местности в зоне контроля оперативника. Если это местность-снаряжение, удалите её. Иначе поместите маркер Пролома (Breach marker) как можно ближе к местности. Пока оперативник находится в пределах 1" от маркера, части местности толщиной до 1" считаются проходимыми (Accessible terrain). Нельзя выполнять под контролем врага или без доступной местности.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, BREAKA BOY, FIGHTER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="breaka-boy-krusha">Разрушитель-крушила (Breaka Boy Krusha)</h3>
+            <p>В тяжёлых доспехах и с пневмокостетами эти орки ломают укрепления и технику одним ударом.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">12</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Костеты «Крушилы» (Knucklebustas)</span>
+                  <span class="weapon-profile">АТК 4 • ПОП 3+ • УРОН 5/6</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Жестокий (Brutal), Шок (Shock), Сокрушение (Smash*)</div>
+              </div>
+            </div>
+            <p><strong>Сокрушение (Smash):</strong> когда вы наносите удар, можете переместить врага по прямой до 1" дальше от вас и в размещаемое положение. Затем переместите этого оперативника по прямой до 1", завершая ход в зоне контроля врага. Если любое перемещение невозможно, игнорируйте правило.</p>
+            <p><strong>Утолщённая броня (Armoured Up):</strong> когда враг стреляет по этому оперативнику или когда он сражается/контратакует, соперник не может превращать результаты ниже 6 в критические успехи (например, за счёт правил Смертельный (Lethal), Рвущий (Rending) или Жестокий (Severe)).</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, BREAKA BOY, KRUSHA. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tankbusta-gunner">Танкоубийца-пушкарь (Tankbusta Gunner)</h3>
+            <p>Вооружённые самыми мощными ракетами, танкоубийцы всегда ищут новую цель для подрыва.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">12</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Тяжёлый ракетомёт (’Eavy rokkit launcha)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 4+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 1" (Blast 1"), Тяжёлый (Heavy, только Dash)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетомёт (Rokkit launcha)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 1" (Blast 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Соперничество (Kompetitive Streak):</strong> раз за действие Стрельба (Shoot), если оперативник стреляет по врагу, которого уже обстреливал другой дружественный оперативник в этот игровой ход, получите 1 очко «Разгрома». Определяйте условие при выборе допустимой цели; вторичные цели (например, от правила Взрыв) учитываются.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, TANKBUSTA, GUNNER. Основание ⌀32 мм.</p>
+          </article>
+
+          <article class="card">
+            <h3 id="tankbusta-rokkiteer">Танкоубийца-ракетчик (Tankbusta Rokkiteer)</h3>
+            <p>Эти орки устанавливают дополнительные пусковые установки с пульсарными ракетами, чтобы вышибать врагов из укрытий.</p>
+            <div class="stat-grid">
+              <div class="stat-item"><span class="stat-label">ДЕЙСТВИЯ (APL)</span><span class="stat-value">2</span></div>
+              <div class="stat-item"><span class="stat-label">ДВИЖЕНИЕ (Move)</span><span class="stat-value">6"</span></div>
+              <div class="stat-item"><span class="stat-label">СПАСБРОСОК (Save)</span><span class="stat-value">4+</span></div>
+              <div class="stat-item"><span class="stat-label">РАНЫ (Wounds)</span><span class="stat-value">12</span></div>
+            </div>
+            <div class="weapon-list">
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Пульсарная ракета (Pulsa rokkit)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН —</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Тяжёлый (Heavy, только Reposition), Ограниченный 1 (Limited 1), Пульса (Pulsa*)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетомёт (Rokkit launcha)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 1" (Blast 1")</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Ракетная батарея (Rokkit rack)</span>
+                  <span class="weapon-profile">АТК 6 • ПОП 5+ • УРОН 4/5</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> Взрыв 2" (Blast 2"), Тяжёлый (Heavy, только Reposition), Ограниченный 1 (Limited 1), Безжалостный (Relentless)</div>
+              </div>
+              <div class="weapon-item">
+                <div class="weapon-header">
+                  <span class="weapon-name">Кулаки (Fists)</span>
+                  <span class="weapon-profile">АТК 3 • ПОП 3+ • УРОН 3/4</span>
+                </div>
+                <div class="weapon-rules"><strong>Правила:</strong> —</div>
+              </div>
+            </div>
+            <p><strong>Пульса (Pulsa):</strong> цель не выбирается. Вместо этого разместите свой маркер «Пульса» (Pulsa marker) в зоне видимости оперативника или на местности с преимуществом высоты (Vantage), которую он видит. Маркер получает 1 очко Пульсы, затем бросьте кубы атаки: за каждый успех маркер получает ещё по 1 очку (до 3 дополнительных). Затем нанесите каждому оперативнику полностью в пределах x" от маркера по D3 урона, где x — количество очков Пульсы. После этого действие завершается.</p>
+            <p><strong>Шоковая волна (Shokkwave):</strong> пока оперативник находится в пределах x" от вашего маркера Пульсы, ухудшайте меткость (Hit) его оружия на 1 и уменьшайте характеристику Движение (Move) на 2". Эффект суммируется с состоянием ранения. В шаге Подготовки (Ready step) каждой Стратегической фазы уменьшайте количество очков Пульсы маркера на 1. Если очков Пульсы становится 0, удалите маркер.</p>
+            <p><strong>Ключевые слова:</strong> WRECKA KREW, ORK, TANKBUSTA, ROKKITEER. Основание ⌀32 мм.</p>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <nav class="page-nav" aria-label="Навигация по листу" data-page-toc data-toc-scope=".sheet" data-toc-target=".section-title, .cards .card h3" data-toc-prefix="wrecka-krew" data-toc-levels=".section-title:2; .cards .card h3:3">
+      <h2>Разделы</h2>
+      <ul class="page-nav-list" data-page-toc-list></ul>
+    </nav>
+  </div>
+</main>
+<script src="scripts.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- добавлены вводные абзацы с переводом художественного текста для правил фракции, плоев и снаряжения Hearthkyn Salvagers, сохранив оригинальные названия в скобках
- уточнена терминология оспаривания маркеров (contest) и исправлены подписи снаряжения, чтобы текст соответствовал глоссарию

## Testing
- not run (статические HTML-страницы)

------
https://chatgpt.com/codex/tasks/task_e_68da5607db608323b2af4fcc078f3608